### PR TITLE
Fix link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A set of helpful assertions when testing Laravel applications.
 
 ## Requirements
-Your application must be running the latest LTS version (5.5) or higher and using [Laravel's testing harness](https://laravel.com/docs/5.8/testing).
+Your application must be running the latest LTS version (5.5) or higher and using [Laravel's testing harness](https://laravel.com/docs/testing).
 
 ## Installation
 You may install these assertions with Composer by running:


### PR DESCRIPTION
Hey @jasonmccreary,

great work on the package. I'm submitting this small fix that will keep the link to Laravel testing harness' documentation always pointing to the latest version of Laravel.

Kind regards,
g