### PR TITLE
Allow assertion to run based on the route name only

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ assertActionUsesFormRequest(string $controller, string $method, string $form_req
 
 Verifies the _action_ for a given controller performs validation using the given form request.
 
+```php
+assertRouteUsesFormRequest(string $routeName, string $formRequest)
+```
+
+Verifies that the corresponding action/controller, for a given _route name_ performs the validation using the given form request.
+
 
 ## Matchers
 ```php

--- a/src/Traits/HttpTestAssertions.php
+++ b/src/Traits/HttpTestAssertions.php
@@ -6,6 +6,22 @@ use PHPUnit\Framework\Assert;
 
 trait HttpTestAssertions
 {
+    public function assertRouteUsesFormRequest(string $routeName, string $formRequest) {
+		$controllerAction = collect(Route::getRoutes())->filter(function (\Illuminate\Routing\Route $route) use ($routeName) {
+			return $route->getName() == $routeName;
+		})->pluck('action.controller');
+
+		Assert::assertNotEmpty($controllerAction, "{$routeName} is not defined within the router.");
+
+		Assert::assertCount(1, $controllerAction, "{$routeName} returns multiple routes.");
+
+		$controllerAction = $controllerAction->first();
+
+		list($controller, $method) = explode('@', $controllerAction);
+
+		$this->assertActionUsesFormRequest($controller, $method, $formRequest);
+	}
+    
     public function assertActionUsesFormRequest(string $controller, string $method, string $form_request)
     {
         Assert::assertTrue(is_subclass_of($form_request, 'Illuminate\\Foundation\\Http\\FormRequest'), $form_request . ' is not a type of Form Request');

--- a/src/Traits/HttpTestAssertions.php
+++ b/src/Traits/HttpTestAssertions.php
@@ -2,6 +2,7 @@
 
 namespace JMac\Testing\Traits;
 
+use Illuminate\Support\Facades\Route;
 use PHPUnit\Framework\Assert;
 
 trait HttpTestAssertions


### PR DESCRIPTION
I prefer to know as little as possible in tests, and something felt a little wrong about using the exact controller + method in order to assert the FormRequest was being used.

This PR allows us to continue to use a piece of information we are already using (i.e. the route name when making the test request), along with our intended FormRequest class (which is now only one implementation detail we've leaked into the test).