### PR TITLE
Assert controller action uses middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ assertActionUsesFormRequest(string $controller, string $method, string $form_req
 
 Verifies the _action_ for a given controller performs validation using the given form request.
 
+```php
+assertActionUsesMiddleware(string $controller, string $method, string|array $middleware)
+```
+
+Verifies the _action_ for a given controller uses the given middleware or set of middleware.
+
 
 ## Matchers
 ```php

--- a/src/Traits/HttpTestAssertions.php
+++ b/src/Traits/HttpTestAssertions.php
@@ -25,4 +25,18 @@ trait HttpTestAssertions
 
         Assert::assertTrue($actual, 'Action "' . $method . '" does not have validation using the "' . $form_request . '" Form Request.');
     }
+
+    public function assertActionUsesMiddleware($controller, $method, $middleware)
+    {
+        $router = resolve(\Illuminate\Routing\Router::class);
+        $route = $router->getRoutes()->getByAction($controller . '@' . $method);
+
+        Assert::assertNotNull($route, 'Unable to find route for controller action (' . $controller . '@' . $method . ')');
+
+        if (is_array($middleware)) {
+            Assert::assertSame([], array_diff($middleware, $route->gatherMiddleware()), 'Controller action does not use middleware (' . implode(', ', $middleware) . ')');
+        } else {
+            Assert::assertTrue(in_array($middleware, $route->gatherMiddleware()), 'Controller action does not use middleware (' . $middleware . ')');
+        }
+    }
 }


### PR DESCRIPTION
This verifies a controller action uses a middleware or set of middleware when passed an `array`.

**Example**

```php
$this->assertActionUsesMiddleware(
    \App\Http\Controllers\AddOnController::class,
    'index',
    ['add-ons', 'auth']
);
```