### PR TITLE
Add assert event has listener

### DIFF
--- a/src/Traits/HttpTestAssertions.php
+++ b/src/Traits/HttpTestAssertions.php
@@ -96,6 +96,21 @@ trait HttpTestAssertions
         }
     }
 
+    public function assertEventHasListener($event, $listener)
+    {
+        $events = [];
+
+        foreach ($this->app->getProviders(EventServiceProvider::class) as $provider) {
+            $providerEvents = array_merge_recursive(
+                $provider->shouldDiscoverEvents() ? $provider->discoverEvents() : [], $provider->listens()
+            );
+
+            $events = array_merge_recursive($events, $providerEvents);
+        }
+
+        PHPUnitAssert::assertContains($listener, $events[$event]);
+    }
+
     private function normalizeRules(array $rules)
     {
         return array_map([$this, 'expandRules'], $rules);


### PR DESCRIPTION
Here is my proposal for adding **Event has Listener Assertion**. I copied the code from Event List Listener artisan command and I added assertion.

Usage:
```
$this->assertEventHasListener(ProfileImageUploadedEvent::class, ResizeImageListener::class);
```

