### PR TITLE
Use broader name for trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Afterwards, add the trait to your base `TestCase` class:
 <?php
 namespace Tests;
 
-use JMac\Testing\Traits\HttpTestAssertions;
+use JMac\Testing\Traits\AdditionalAssertions;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    use CreatesApplication, HttpTestAssertions;
+    use CreatesApplication, AdditionalAssertions;
 }
 ```
 

--- a/src/Traits/AdditionalAssertions.php
+++ b/src/Traits/AdditionalAssertions.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Route;
 use PHPUnit\Framework\Assert as PHPUnitAssert;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
-trait HttpTestAssertions
+trait AdditionalAssertions
 {
     public function assertRouteUsesFormRequest(string $routeName, string $formRequest)
     {


### PR DESCRIPTION
This the renames `HttpTestAssertions` trait to `AdditionalAssertions` to communicate the now broader use of the assertions within this package.

**Please note, this is a breaking change** and will be released in the 1.0.