### PR TITLE
Assertions for verifying the data types of arrays

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,12 @@
         "psr-4": {
             "JMac\\Testing\\": "src/"
         }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "JMac\\Testing\\AdditionalAssertionsServiceProvider"
+            ]
+        }
     }
 }

--- a/src/AdditionalAssertionsServiceProvider.php
+++ b/src/AdditionalAssertionsServiceProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace JMac\Testing;
+
+use Illuminate\Support\ServiceProvider;
+use JMac\Testing\Traits\AdditionalAssertions;
+
+class AdditionalAssertionsServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        $test_response_class = class_exists(\Illuminate\Testing\TestResponse::class)
+            ? \Illuminate\Testing\TestResponse::class
+            : \Illuminate\Foundation\Testing\TestResponse::class;
+
+        if (!$test_response_class::hasMacro('assertJsonTypedStructure')) {
+            $test_response_class::macro('assertJsonTypedStructure', function (array $structure) {
+                AdditionalAssertions::assertArrayStructure($structure, $this->json());
+
+                return $this;
+            });
+        }
+    }
+}
+
+

--- a/src/Traits/AdditionalAssertions.php
+++ b/src/Traits/AdditionalAssertions.php
@@ -108,6 +108,44 @@ trait AdditionalAssertions
         }
     }
 
+    public static function assertArrayStructure(array $structure, array $actual)
+    {
+        foreach ($structure as $key => $type) {
+            if (is_array($type) && $key === '*') {
+                PHPUnitAssert::assertIsArray($actual);
+
+                foreach ($actual as $data) {
+                    static::assertArrayStructure($structure['*'], $data);
+                }
+            } elseif (is_array($type) && array_key_exists($key, $structure)) {
+                if (is_array($structure[$key])) {
+                    static::assertArrayStructure($structure[$key], $actual[$key]);
+                }
+            } else {
+                switch ($type) {
+                    case 'string':
+                        PHPUnitAssert::assertIsString($actual[$key]);
+                        break;
+                    case 'integer':
+                        PHPUnitAssert::assertIsInt($actual[$key]);
+                        break;
+                    case 'number':
+                        PHPUnitAssert::assertIsNumeric($actual[$key]);
+                        break;
+                    case 'boolean':
+                        PHPUnitAssert::assertIsBool($actual[$key]);
+                        break;
+                    case 'array':
+                        PHPUnitAssert::assertIsArray($actual[$key]);
+                        break;
+                    default:
+                        PHPUnitAssert::fail('unexpected type: ' . $type);
+                }
+            }
+        }
+    }
+
+
     private function normalizeRules(array $rules)
     {
         return array_map([$this, 'expandRules'], $rules);


### PR DESCRIPTION
This PR is inspired by [#16067](https://github.com/laravel/framework/pull/16067). It provides this functionality by adding an `assertJsonTypedStructure` method on the `TestResponse` class.

For example, the following JSON response:

```json
{
   "name": "Jason McCreary",
   "age": 38,
   "height": 6.1,
   "male": true,
   "attributes": {
      "hair":"brown",
      "eyes":"brown"
   },
   "hobbies": ["programming", "woodworking", "cooking"],
   "languages": [
      {"name":"PHP"},
      {"name":"JavaScript"}
   ]
}
```

Could be verified with:

```php
$response->assertJsonTypedStructure([
    'name' => 'string',
    'age' => 'integer',
    'height' => 'number',
    'male' => 'boolean',
    'attributes' => [
        'hair' => 'string',
        'eyes' => 'string',
    ],
    'hobbies' => 'array'
    'languages' => [
        '*' => [
            'name' => 'string',
        ]
    ],
]);
```

The underlying verification of the array structure was also broken out to a generic `assertArrayStructure` method on the `AdditionalAssertions` trait.
