### PR TITLE
Add assertion for Model not soft deleted

### DIFF
--- a/src/Traits/AdditionalAssertions.php
+++ b/src/Traits/AdditionalAssertions.php
@@ -3,6 +3,7 @@
 namespace JMac\Testing\Traits;
 
 use Illuminate\Support\Facades\Route;
+use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\Assert as PHPUnitAssert;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
@@ -178,6 +179,13 @@ trait AdditionalAssertions
         }
     }
 
+    public function assertModelNotSoftDeleted(Model $model)
+    {
+        return $this->assertDatabaseHas($model->getTable(), [
+            $model->getKeyName() => $model->getKey(),
+            'deleted_at' => null,
+        ]);
+    }
 
     private function normalizeRules(array $rules)
     {

--- a/src/Traits/AdditionalAssertions.php
+++ b/src/Traits/AdditionalAssertions.php
@@ -179,7 +179,7 @@ trait AdditionalAssertions
         }
     }
 
-    public function assertModelNotSoftDeleted(Model $model)
+    public function assertNotSoftDeleted(Model $model)
     {
         return $this->assertDatabaseHas($model->getTable(), [
             $model->getKeyName() => $model->getKey(),


### PR DESCRIPTION
Adds an assertion for model not being soft deleted. This works as an inverse assertion of [`assertSoftDeleted`](https://laravel.com/docs/8.x/database-testing#assert-deleted)

Closes #27