### PR TITLE
Only support latest stable Laravel version

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,6 @@ assertValidationRuleContains($rule, string $class)
 
 Verifies the rule or rules contains an instance of the given [Rule](https://laravel.com/docs/validation#custom-validation-rules) class.
 
-```php
-assertNotSoftDeleted(Model $model)
-```
-
-Verifies the given model is not _soft deleted_, providing the inverse of [assertSoftDeleted](https://laravel.com/docs/database-testing#available-assertions).
-
 ## Matchers
 ```php
 LaravelMatchers::isModel(Model $model = null)
@@ -111,3 +105,8 @@ createFormRequest(string $class, array $data = [])
 ```
 
 Creates an instance of the given [Form Request](https://laravel.com/docs/7.x/validation#form-request-validation) class with the given request data.
+
+## Support Policy
+Starting with version 2, this package will only support the latest stable version of Laravel (currently Laravel 8). If you need to support older versions of Laravel, you may use version 1 or upgrade your application ([try using Shift](https://laravelshift.com)).
+
+This package still follows [semantic versioning](https://semver.org/). However, it does so with respect to its own code. Any breaking changes will increase its major version number. Otherwise, minor version number increases will contain new features. This includes changes for future versions of Laravel.

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,10 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
-        "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^7.5|^8.0|^9.0"
+        "php": ">=7.3",
+        "illuminate/testing": "^8.0",
+        "mockery/mockery": "^1.4.2",
+        "phpunit/phpunit": "^9.3.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/AdditionalAssertionsServiceProvider.php
+++ b/src/AdditionalAssertionsServiceProvider.php
@@ -9,12 +9,8 @@ class AdditionalAssertionsServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        $test_response_class = class_exists(\Illuminate\Testing\TestResponse::class)
-            ? \Illuminate\Testing\TestResponse::class
-            : \Illuminate\Foundation\Testing\TestResponse::class;
-
-        if (!$test_response_class::hasMacro('assertJsonTypedStructure')) {
-            $test_response_class::macro('assertJsonTypedStructure', function (array $structure) {
+        if (!\Illuminate\Testing\TestResponse::hasMacro('assertJsonTypedStructure')) {
+            \Illuminate\Testing\TestResponse::macro('assertJsonTypedStructure', function (array $structure) {
                 AdditionalAssertions::assertArrayStructure($structure, $this->json());
 
                 return $this;

--- a/src/Traits/AdditionalAssertions.php
+++ b/src/Traits/AdditionalAssertions.php
@@ -2,8 +2,8 @@
 
 namespace JMac\Testing\Traits;
 
-use Illuminate\Support\Facades\Route;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Route;
 use PHPUnit\Framework\Assert as PHPUnitAssert;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
@@ -113,11 +113,7 @@ trait AdditionalAssertions
 
     public function assertValidationRules(array $expected, array $actual)
     {
-        if (class_exists(\Illuminate\Testing\Assert::class)) {
-            \Illuminate\Testing\Assert::assertArraySubset($this->normalizeRules($expected), $this->normalizeRules($actual));
-        } else {
-            \Illuminate\Foundation\Testing\Assert::assertArraySubset($this->normalizeRules($expected), $this->normalizeRules($actual));
-        }
+        \Illuminate\Testing\Assert::assertArraySubset($this->normalizeRules($expected), $this->normalizeRules($actual));
     }
 
     public function assertExactValidationRules(array $expected, array $actual)
@@ -177,14 +173,6 @@ trait AdditionalAssertions
                 }
             }
         }
-    }
-
-    public function assertNotSoftDeleted(Model $model)
-    {
-        return $this->assertDatabaseHas($model->getTable(), [
-            $model->getKeyName() => $model->getKey(),
-            'deleted_at' => null,
-        ]);
     }
 
     private function normalizeRules(array $rules)


### PR DESCRIPTION
Support for older versions of Laravel creates a drag on packages. To make maintenance and contributions easier, this package will only support the latest stable Laravel version.

To make a clean break, this change will be reflected by a major version number increase (2.0). However, future major versions will on increase to reflect breaking changes to the API, not simply new Laravel versions.

---
Closes #30