### PR TITLE
Take excluded_middleware into account for middleware assertions

### DIFF
--- a/src/Traits/AdditionalAssertions.php
+++ b/src/Traits/AdditionalAssertions.php
@@ -66,10 +66,12 @@ trait AdditionalAssertions
             PHPUnitAssert::assertNotNull($route, 'Unable to find route for controller action (' . $controller . '@' . $method . ')');
         }
 
+        $usedMiddlewares = array_diff($route->gatherMiddleware(), $route->action['excluded_middleware']);
+
         if (is_array($middleware)) {
-            PHPUnitAssert::assertSame([], array_diff($middleware, $route->gatherMiddleware()), 'Controller action does not use middleware (' . implode(', ', $middleware) . ')');
+            PHPUnitAssert::assertSame([], array_diff($middleware, $usedMiddlewares), 'Controller action does not use middleware (' . implode(', ', $middleware) . ')');
         } else {
-            PHPUnitAssert::assertTrue(in_array($middleware, $route->gatherMiddleware()), 'Controller action does not use middleware (' . $middleware . ')');
+            PHPUnitAssert::assertTrue(in_array($middleware, $usedMiddlewares), 'Controller action does not use middleware (' . $middleware . ')');
         }
     }
 
@@ -78,7 +80,7 @@ trait AdditionalAssertions
         $router = resolve(\Illuminate\Routing\Router::class);
 
         $route = $router->getRoutes()->getByName($routeName);
-        $usedMiddlewares = $route->gatherMiddleware();
+        $usedMiddlewares = array_diff($route->gatherMiddleware(), $route->action['excluded_middleware']);
 
         PHPUnitAssert::assertNotNull($route, "Unable to find route for name `$routeName`");
 

--- a/src/Traits/AdditionalAssertions.php
+++ b/src/Traits/AdditionalAssertions.php
@@ -66,7 +66,8 @@ trait AdditionalAssertions
             PHPUnitAssert::assertNotNull($route, 'Unable to find route for controller action (' . $controller . '@' . $method . ')');
         }
 
-        $usedMiddlewares = array_diff($route->gatherMiddleware(), $route->action['excluded_middleware']);
+        $excludedMiddleware = $route->action['excluded_middleware'] ?? [];
+        $usedMiddlewares = array_diff($route->gatherMiddleware(), $excludedMiddleware);
 
         if (is_array($middleware)) {
             PHPUnitAssert::assertSame([], array_diff($middleware, $usedMiddlewares), 'Controller action does not use middleware (' . implode(', ', $middleware) . ')');
@@ -80,7 +81,9 @@ trait AdditionalAssertions
         $router = resolve(\Illuminate\Routing\Router::class);
 
         $route = $router->getRoutes()->getByName($routeName);
-        $usedMiddlewares = array_diff($route->gatherMiddleware(), $route->action['excluded_middleware']);
+
+        $excludedMiddleware = $route->action['excluded_middleware'] ?? [];
+        $usedMiddlewares = array_diff($route->gatherMiddleware(), $excludedMiddleware);
 
         PHPUnitAssert::assertNotNull($route, "Unable to find route for name `$routeName`");
 


### PR DESCRIPTION
This PR addresses the bug in the issue https://github.com/jasonmccreary/laravel-test-assertions/issues/37.