### PR TITLE
Add assertion to route group middleware

### DIFF
--- a/src/Traits/AdditionalAssertions.php
+++ b/src/Traits/AdditionalAssertions.php
@@ -82,13 +82,16 @@ trait AdditionalAssertions
 
         $route = $router->getRoutes()->getByName($routeName);
 
+        PHPUnitAssert::assertNotNull($route, "Unable to find route for name `$routeName`");
+
         $excludedMiddleware = $route->action['excluded_middleware'] ?? [];
         $usedMiddlewares = array_diff($route->gatherMiddleware(), $excludedMiddleware);
 
-        PHPUnitAssert::assertNotNull($route, "Unable to find route for name `$routeName`");
+        $unusedMiddlewares = array_diff($middlewares, $usedMiddlewares);
+
+        PHPUnitAssert::assertTrue(count($unusedMiddlewares) === 0, "Route `$routeName` does not use expected `" . implode(', ', $unusedMiddlewares) . "` middleware(s)");
 
         if ($exact) {
-            $unusedMiddlewares = array_diff($middlewares, $usedMiddlewares);
             $extraMiddlewares = array_diff($usedMiddlewares, $middlewares);
 
             $messages = [];
@@ -104,10 +107,6 @@ trait AdditionalAssertions
             $messages = implode(" and ", $messages);
 
             PHPUnitAssert::assertTrue(count($unusedMiddlewares) + count($extraMiddlewares) === 0, "Route `$routeName` " . $messages);
-        } else {
-            $unusedMiddlewares = array_diff($middlewares, $usedMiddlewares);
-
-            PHPUnitAssert::assertTrue(count($unusedMiddlewares) === 0, "Route `$routeName` does not use expected `" . implode(', ', $unusedMiddlewares) . "` middleware(s)");
         }
     }
 

--- a/src/Traits/AdditionalAssertions.php
+++ b/src/Traits/AdditionalAssertions.php
@@ -76,6 +76,19 @@ trait AdditionalAssertions
         }
     }
 
+    public function assertMiddlewareGroupUsesMiddleware(string $middlewareGroup, array $middlewares)
+    {
+        $router = resolve(\Illuminate\Routing\Router::class);
+
+        $kernel = new \App\Http\Kernel(app(), $router);
+
+        $middlewareGroups = $kernel->getMiddlewareGroups();
+
+        $missingMiddlware = array_diff($middlewares, $middlewareGroups[$middlewareGroup]);
+
+        PHPUnitAssert::assertTrue(count($missingMiddlware) === 0, "Middlware Group `$middlewareGroup` does not use expected `" . implode(', ', $missingMiddlware) . "` middleware(s)");
+    }
+
     public function assertRouteUsesMiddleware(string $routeName, array $middlewares, bool $exact = false)
     {
         $router = resolve(\Illuminate\Routing\Router::class);


### PR DESCRIPTION
Long time user of this package, thanks again for making it! Recently, I found it difficult to make assertions on middleware nested within a middleware group. In order to hopefully not create backward compatibility issues by heavily refactoring the `assertRouteUsesMiddleware` I have opted for a new assertion method to be added called `assertMiddlewareGroupUsesMiddleware`. 

An example usage of this new function may look something like this.

```php
/** @test */
public function route_uses_desired_middleware(): void
{
     // Below we check if the middleware group is used with existing functionality
    $this->assertRouteUsesMiddleware('welcome.show', ['web']);
    // Next we can use the new assertion to be sure the `web` group uses specific middleware(s)
    $this->assertMiddlewareGroupUsesMiddleware('web', [HandleInertiaRequests::class]); 
}
```

I noticed there isn't a test suite in the package to run, I did some manual testing and everything seemed to work fine, but please advise if there's any test coverage that can be added somewhere or changes that may be desired ✌️