### PR TITLE
Fix assertExactValidationRules on PHPUnit 12 with closures in rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ assertExactValidationRules(array $expected, array $actual)
 
 Verifies the expected set of validation rules for fields exactly match a set of validation rules. Rules may be passed as a delimited string or array.
 
+**Note**: closures within a rule set are compared by presence and position, not by behavior. PHP offers no way to compare two closures functionally, so a closure in the expected rules only asserts that _some_ closure sits in that position. To cover what a closure does, extract it from `rules()` into a [`ValidationRule`](https://laravel.com/docs/validation#custom-validation-rules) class and test it separately.
+
 
 ```php
 assertValidationRuleContains($rule, string $class)

--- a/src/Comparators/ClosuresAreEqualComparator.php
+++ b/src/Comparators/ClosuresAreEqualComparator.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace JMac\Testing\Comparators;
+
+use Closure;
+use SebastianBergmann\Comparator\Comparator;
+
+/**
+ * Treats any two closures as equal.
+ *
+ * PHPUnit 12 added SebastianBergmann\Comparator\ClosureComparator, which only
+ * considers closures equal when their declaration matches -- same file name and
+ * same start and end line. Validation rules routinely contain closures, and the
+ * expected closure is declared in the test while the actual one is declared in
+ * the form request, so that check can never pass.
+ *
+ * On PHPUnit 11 there was no such comparator. Closures fell through to the
+ * object comparator and compared equal because a Closure exposes no properties,
+ * so the assertion never actually inspected them. This comparator keeps that
+ * behavior explicit rather than relying on the absence of a comparator.
+ *
+ * PHP offers no way to compare two closures by behavior, so an assertion can
+ * only establish that a closure is present in a given position. Tests that need
+ * to pin down what a closure does should extract it from rules() and cover it
+ * separately.
+ */
+final class ClosuresAreEqualComparator extends Comparator
+{
+    public function accepts(mixed $expected, mixed $actual): bool
+    {
+        return $expected instanceof Closure && $actual instanceof Closure;
+    }
+
+    public function assertEquals(mixed $expected, mixed $actual, float $delta = 0.0, bool $canonicalize = false, bool $ignoreCase = false): void
+    {
+        // Two closures always compare equal; there is nothing to report.
+    }
+}

--- a/src/Traits/AdditionalAssertions.php
+++ b/src/Traits/AdditionalAssertions.php
@@ -6,7 +6,9 @@ use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Route;
+use JMac\Testing\Comparators\ClosuresAreEqualComparator;
 use PHPUnit\Framework\Assert as PHPUnitAssert;
+use SebastianBergmann\Comparator\Factory as ComparatorFactory;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 trait AdditionalAssertions
@@ -117,7 +119,9 @@ trait AdditionalAssertions
 
     public function assertExactValidationRules(array $expected, array $actual): void
     {
-        PHPUnitAssert::assertEquals($this->normalizeRules($expected), $this->normalizeRules($actual));
+        $this->comparingClosuresLeniently(function () use ($expected, $actual) {
+            PHPUnitAssert::assertEquals($this->normalizeRules($expected), $this->normalizeRules($actual));
+        });
     }
 
     public function assertMiddlewareGroupUsesMiddleware(string $middlewareGroup, array $middlewares): void
@@ -232,6 +236,26 @@ trait AdditionalAssertions
         Carbon::setTestNow($now);
 
         return $now;
+    }
+
+    /**
+     * Run an assertion with any two closures considered equal.
+     *
+     * Registration is scoped to the assertion so the comparator never leaks into
+     * unrelated comparisons in the consuming test suite. PHPUnit's own
+     * TestCase::registerComparator() would hold for the rest of the test, which
+     * would silently make an unrelated assertEquals() on closures pass as well.
+     */
+    private function comparingClosuresLeniently(callable $assertion): void
+    {
+        $comparator = new ClosuresAreEqualComparator;
+        ComparatorFactory::getInstance()->register($comparator);
+
+        try {
+            $assertion();
+        } finally {
+            ComparatorFactory::getInstance()->unregister($comparator);
+        }
     }
 
     private function expandRules($rule)


### PR DESCRIPTION
PHPUnit 12 ships SebastianBergmann\Comparator\ClosureComparator, which only considers two closures equal when their declaration matches -- same name, file and start/end line. For this assertion that can never hold: the expected closure is declared in the test and the actual one in the form request, so the file names differ by construction. Any rule set containing a closure fails, including anything built with Rule::unique()->where(), Rule::requiredIf() or Rule::exists()->where().

On PHPUnit 11 there was no such comparator. Closures fell through to the object comparator and compared equal because a Closure exposes no properties, so the assertion never actually inspected them.

Register a comparator that treats any two closures as equal, scoped to the assertion with try/finally so it never leaks into unrelated comparisons in the consuming suite. Normalizing the rules array instead was rejected: closures frequently sit in private properties of Laravel's own rule objects, where a comparator reaches them but a normalizer cannot.

Closures are therefore compared by presence and position, not by behavior. PHP offers no way to compare two closures functionally, so this is documented in the README.